### PR TITLE
hotfix/go-fmt

### DIFF
--- a/api/Models/TestModel.go
+++ b/api/Models/TestModel.go
@@ -1,7 +1,6 @@
 package Models
 
 import (
-	"fmt"
 	"github.com/jinzhu/gorm"
 	"github.com/yeomko22/groove/api/Network"
 )

--- a/api/Models/UserModel.go
+++ b/api/Models/UserModel.go
@@ -1,7 +1,6 @@
 package Models
 
 import (
-	"fmt"
 	"github.com/jinzhu/gorm"
 	"github.com/yeomko22/groove/api/Network"
 )


### PR DESCRIPTION
- go fmt 버그 때문에 빌드가 진행되지 않는 현상 발생, 이를 수정