### PR TITLE
feature/api-track

### DIFF
--- a/api/Controllers/TrackController.go
+++ b/api/Controllers/TrackController.go
@@ -1,9 +1,11 @@
 package Controllers
 
 import (
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/yeomko22/groove/api/Models"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -108,25 +110,38 @@ func GetTrackHottest(c *gin.Context) {
 // @Router /tracks/user/:userId [get]
 // @Description 특정 유저가 업로드한 트랙을 페이징 처리해서 읽어옴
 // @Param user_id path string true "user_id"
-// @Param option query int false "1|2|3, 어떤 기준으로 트랙을 읽어올 것인가, 기본값 1"
-// @Param page query int false "10개 단위로 페이징 처리, 몇 번째 페이지를 읽어올 것인가, 기본값 0"
+// @Param option path int false "1|2|3, 어떤 기준으로 트랙을 읽어올 것인가, 기본값 1"
+// @Param limit path int false "한번에 몇개의 트랙 정보를 가져올 것인가, 기본값 10"
+// @Param offset path int false "몇번째 트랙부터 정보를 가져올 것이가, 기본값 0"
 // @Success 200 {object} Models.TrackResponse
 // @Tags tracks
 func GetTrackByUser(c *gin.Context) {
 	userId := c.Param("userId")
-	pageInfo := Models.NewPageInfo()
-	err := c.BindJSON(&pageInfo)
+	option, err := strconv.Atoi(c.DefaultQuery("option", "1"))
 	if err != nil {
 		c.AbortWithStatus(http.StatusBadRequest)
-		return
+	}
+	limit, err := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	if err != nil {
+		c.AbortWithStatus(http.StatusBadRequest)
+	}
+	offset, err := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	if err != nil {
+		c.AbortWithStatus(http.StatusBadRequest)
 	}
 	var tracks []Models.Track
-	err = Models.GetTrackByUser(&tracks, userId, pageInfo)
+	err = Models.GetTrackByUser(&tracks, userId, option, limit, offset)
 	if err != nil {
-		c.AbortWithStatus(http.StatusNotFound)
-		return
+		c.AbortWithStatus(http.StatusInternalServerError)
 	}
-	c.JSON(http.StatusOK, tracks)
+	var count int
+	err = Models.GetTrackByUserCount(&count, userId)
+	if err != nil {
+		c.AbortWithStatus(http.StatusInternalServerError)
+	}
+	nextUrl := getNextUrl(userId, option, limit, offset, count)
+	c.JSON(http.StatusOK,
+		Models.NewTracksByUserResponse(http.StatusOK, tracks, option, limit, offset, nextUrl))
 }
 
 // @Router /tracks/increase [put]
@@ -150,4 +165,17 @@ func IncreaseTrackField(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK,
 		Models.NewTrackResponse(http.StatusOK, track))
+}
+
+func getNextUrl(userId string, option, limit, offset, count int) string {
+	nextUrl := ""
+	if offset+limit < count {
+		newOffset := offset + limit
+		newLimit := limit
+		if count-newOffset < limit {
+			newLimit = count - newOffset
+		}
+		nextUrl = fmt.Sprintf("/tracks/user/%s?option=%d&limit=%d&offset=%d", userId, option, newOffset, newLimit)
+	}
+	return nextUrl
 }

--- a/api/Models/Response.go
+++ b/api/Models/Response.go
@@ -24,6 +24,26 @@ func NewTracksResponse(code int, tracks []Track) TracksResponse {
 	return response
 }
 
+type TracksByUserResponse struct {
+	Code    int     `json:"code"`
+	Limit   int     `json:"limit"`
+	Offset  int     `json:"offset"`
+	Option  int     `json:"option"`
+	NextUrl string  `json:"next_url"`
+	Tracks  []Track `json:"tracks"`
+}
+
+func NewTracksByUserResponse(code int, tracks []Track, limit, offset, option int, nextUrl string) TracksByUserResponse {
+	var response TracksByUserResponse
+	response.Code = code
+	response.Tracks = tracks
+	response.Limit = limit
+	response.Offset = offset
+	response.Option = option
+	response.NextUrl = nextUrl
+	return response
+}
+
 type GenresResponse struct {
 	Code   int     `json:"code"`
 	Genres []Genre `json:"genres"`

--- a/api/Models/TrackModel.go
+++ b/api/Models/TrackModel.go
@@ -113,9 +113,9 @@ func GetTrackHottest(tracks *[]Track) (err error) {
 // 1: newest track
 // 2: most liked
 // 3: most played
-func GetTrackByUser(tracks *[]Track, userId string, pageInfo PageInfo) (err error) {
+func GetTrackByUser(tracks *[]Track, userId string, option, limit, offset int) (err error) {
 	var order string
-	switch pageInfo.Option {
+	switch option {
 	case 1:
 		order = "created_at desc"
 	case 2:
@@ -126,9 +126,20 @@ func GetTrackByUser(tracks *[]Track, userId string, pageInfo PageInfo) (err erro
 	err = Network.DB.Table("tracks").
 		Where("track_user_id = ?", userId).
 		Order(order).
-		Offset(10 * pageInfo.Page).
-		Limit(10).
+		Offset(offset).
+		Limit(limit).
 		Find(tracks).
+		Error
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetTrackByUserCount(count *int, userId string) (err error) {
+	err = Network.DB.Table("tracks").
+		Where("track_user_id = ?", userId).
+		Count(count).
 		Error
 	if err != nil {
 		return err


### PR DESCRIPTION
- 유저 아이디로 트랙 가져오는 부분 수정
- 기존에는 페이지 정보와 offset 정보를 body에 실어서 전달하였는데 이 부분을 url에 담아서 보내는 걸로 변경
- 예시
- /api/tracks/user/yebit (아무 페이지 설정 없이 그냥 보내면 기본값으로 출력함)
- /api/tracks/user/yebit?option=1&limit=20&offset=20 (최신순으로 20개씩 20번째 트랙부터 읽어옴. 페이징 적용)